### PR TITLE
reactive props issue example

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -71,6 +71,14 @@
 
 {#if centerText}
   <p>{centerText}</p>
+  <p><label>Zoom: <input disabled={true} value={zoom} /></label></p>
+  <p>
+    <button
+      on:click={() => {
+        zoom = 1;
+      }}>Zoom to level 1</button
+    >
+  </p>
 {/if}
 
 <style>


### PR DESCRIPTION
This sample shows passing in an attirbute into the web component and then modifying it.

## Issue replication case:
1. Checkout this branch
2. `npm install`
3. `npm run dev`
4. Click the "Aoom to level 1" button
    - Expected: just like the value in the text box has changed to `1`, I would expect the zoom level of the map to zoom to level `1` because the attributes have been passed in the same way
    - Actual: the text box value changes to `1` but the map does not change.
![image](https://github.com/gavinr-maps/esri-svelte-example/assets/137905994/69a754dd-18a1-41ae-a974-5522cc888081)

## Other notes

- Note that this DOES work as expected with React: https://codepen.io/gavinr/pen/OJdGKwx?editors=0010